### PR TITLE
Changed the getReplacementInstances attribute to type DatabaseObject …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <packaging>jar</packaging>
     <!-- Try to match with the dev (master) branch -->
-    <version>3.0.1.CT</version>
+    <version>3.0.2.CT</version>
     <name>Graph Core Next Generation</name>
 
     <description>
@@ -111,6 +111,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.voodoodyne.jackson.jsog</groupId>
+            <artifactId>jackson-jsog</artifactId>
+            <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/reactome/server/graph/domain/model/Deleted.java
+++ b/src/main/java/org/reactome/server/graph/domain/model/Deleted.java
@@ -21,7 +21,7 @@ public class Deleted extends MetaDatabaseObject{
     private DeletedControlledVocabulary reason;
 
     @Relationship(type="replacementInstances")
-    private List<Deletable> replacementInstances;
+    private List<DatabaseObject> replacementInstances;
 
     @Deprecated
     @ReactomeProperty(originName = "deletedInstanceDB_ID")
@@ -65,11 +65,11 @@ public class Deleted extends MetaDatabaseObject{
         this.reason = reason;
     }
 
-    public List<Deletable> getReplacementInstances() {
+    public List<DatabaseObject> getReplacementInstances() {
         return replacementInstances;
     }
 
-    public void setReplacementInstances(List<Deletable> replacementInstances) {
+    public void setReplacementInstances(List<DatabaseObject> replacementInstances) {
         this.replacementInstances = replacementInstances;
     }
 

--- a/src/test/java/org/reactome/server/graph/service/DeletedServiceTest.java
+++ b/src/test/java/org/reactome/server/graph/service/DeletedServiceTest.java
@@ -22,7 +22,7 @@ public class DeletedServiceTest extends BaseTest {
         List<DeletedInstance> deletedInstances = deleted.get().getDeletedInstance();
         Assertions.assertTrue(!deletedInstances.isEmpty());
 
-        List<Deletable> deletables = deleted.get().getReplacementInstances();
+        List<DatabaseObject> deletables = deleted.get().getReplacementInstances();
         Assertions.assertTrue(!deletables.isEmpty());
 
         DeletedControlledVocabulary dcv = deleted.get().getReason();


### PR DESCRIPTION
…to allow all classes rather than PE, Event, and Regulation exclusively.